### PR TITLE
Fix "display" value in the "caveats" doc

### DIFF
--- a/build/infinity.js
+++ b/build/infinity.js
@@ -18,7 +18,7 @@
   //
   // 1. All DOM elements must either be visible or in the current layout.
   // infinity.js does not support elements that will at some point affect the
-  // layout, but are currently hidden using `display:block`.
+  // layout, but are currently hidden using `display:none`.
   //
   // 2. ListViews can't be nested.
   //

--- a/docs/infinity.html
+++ b/docs/infinity.html
@@ -14,7 +14,7 @@ performance of long- or infinitely-scrolling lists of items.</p>
 <ol>
 <li><p>All DOM elements must either be visible or in the current layout.
 infinity.js does not support elements that will at some point affect the
-layout, but are currently hidden using <code>display:block</code>.</p></li>
+layout, but are currently hidden using <code>display:none</code>.</p></li>
 <li><p>ListViews can't be nested.</p></li>
 <li><p>Non-ListItem elements can't be the immediate children of ListView
 elements. Only ListItems can be immediate children of ListViews.</p></li>

--- a/infinity.js
+++ b/infinity.js
@@ -18,7 +18,7 @@
   //
   // 1. All DOM elements must either be visible or in the current layout.
   // infinity.js does not support elements that will at some point affect the
-  // layout, but are currently hidden using `display:block`.
+  // layout, but are currently hidden using `display:none`.
   //
   // 2. ListViews can't be nested.
   //


### PR DESCRIPTION
Small typo, an element is hidden using `display:hidden`, not `display:block`. Or am I misinterpreting something?
