### PR TITLE
Added support for in element scrolling

### DIFF
--- a/infinity.js
+++ b/infinity.js
@@ -591,9 +591,9 @@
 
       detach: function(listView) {
         var index, length;
-        if(!listView.eventIsBound) {
+        if(listView.eventIsBound) {
           listView.$scrollParent.on('scroll', scrollHandler);
-          listView.eventIsBound = true;
+          listView.eventIsBound = false;
         }
 
         for(index = 0, length = boundViews.length; index < length; index++) {


### PR DESCRIPTION
Added support for infinite scrolling for elements with overflow set to
auto. This is enabled via the `options` hash by setting
`useElementScroll` to `true`
#14
