### PR TITLE
Added support to turn off repartitioning on resize

### DIFF
--- a/infinity.js
+++ b/infinity.js
@@ -82,6 +82,11 @@
 
     initBuffer(this);
 
+    // Provide a method to disable repartitioning.
+    // Repartitioning is called unnecessarily due to the `window` being faux resized whenever
+    // an item is added to the `ListView` on a mobile web device.
+    this.repartitionOnResize = options.repartitionOnResize !== false;
+
     this.top = this.$el.offset().top;
     this.width = 0;
     this.height = 0;
@@ -305,6 +310,10 @@
         nextItem,
         pages = listView.pages,
         newPages = [];
+
+    if (!listView.repartitionOnResize) {
+      return;
+    }
 
     newPage = new Page(listView);
     newPages.push(newPage);


### PR DESCRIPTION
Repartitioning is called unnecessarily due to the `window` being faux
resized whenever an item is added to the `ListView` on a mobile web
device.

To work around this issue, an option is added to disable this
functionality.
